### PR TITLE
Stub wasi examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "host-wasmi",
+ "wasi-stub",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "equivalent"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "host-wasmi"
@@ -41,11 +47,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
@@ -125,12 +131,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "syn"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb8d4cebc40aa517dfb69618fa647a346562e67228e2236ae0042ee6ac14775"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "test-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "cfg-if",
  "host-wasmi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -153,15 +190,16 @@ dependencies = [
 name = "wasi-stub"
 version = "0.1.0"
 dependencies = [
+ "thiserror",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+checksum = "06a3d1b4a575ffb873679402b2aedb3117555eb65c27b1b86c8a91e574bc2a2a"
 dependencies = [
  "leb128",
 ]
@@ -209,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.107.0"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
+checksum = "8bf9564f29de2890ee34406af52d2a92dec6ef044c8ddfc5add5db8dcfd36e6c"
 dependencies = [
  "indexmap",
  "semver",

--- a/README.md
+++ b/README.md
@@ -39,19 +39,15 @@ The example can run using [`wasmi`](https://github.com/paritytech/wasmi).
 The command to run examples (from the top-level directory) is:
 
 ```sh
-cargo run -- <lang>
+cargo run [--features wasi] -- <lang>
 # or
-cargo run --no-default-features --features <abi> -- <lang>
-# or
-cargo run -- -i <PATH> <func> <args>
-# or
-cargo run --no-default-features --features <abi> -- -i <PATH> <func> <args>
+cargo run [--features wasi] -- -i <PATH> <func> <args>
 ```
 
 Where:
 
 - `<lang>` is `rust`, `zig` or `c`
-- `<abi>` is `abi_unknown` or `abi_wasi` (defaults to `abi_unknown`)
+- add `wasi` to the list of features to compile the example with WASI (required on the C example) and stub all the resulting WASI function if the runner is `host-wasmi`.
 - `<PATH>` is the path to a wasm file
 - `<func>` is the exported function to call in the wasm file, with `<args>` as arguments
 
@@ -65,16 +61,16 @@ Where:
 
 ```sh
 cargo run -- rust # compile and run the Rust example
+cargo run --features wasi -- rust # compile and run the Rust example with WASI (stubbed)
 cargo run -- zig # compile and run the Zig example
-# TODO irrelevant until next PR is merged
-# NOTE: this needs the abi_wasi feature, because the wasi functions are not stubbed. See the 'Tips' section to learn more.
-cargo run -- c # compile and run the C example
+# NOTE: this needs the wasi feature, as `emcc` only compiles in WASI.
+cargo run --features wasi -- c # compile and run the C example
 cargo run -- -i MY_WASM_FILE.wasm MY_FUNCTION arg1 arg2
 ```
 
 ### Tips
 
-- If the runner complains about missing definition for `wasi_snapshot_preview1` functions, try running your `.wasm` through [wasi-stub](./wasi-stub/). It stubs all wasi function in your wasm, so don't expect print or read_file to work anymore.
+- `host-wasmi` does not support running with WASI, and will stub all WASI functions instead.
 - host-wasmi compiles fastest 😉
 
 ## You need to stub a WebAssembly plugin

--- a/examples/test-runner/Cargo.toml
+++ b/examples/test-runner/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.71"
-host-wasmi = { path = "../host-wasmi" }
 cfg-if = "1.0.0"
+host-wasmi = { path = "../host-wasmi" }
+wasi-stub = { path = "../../wasi-stub", optional = true }
 
 
 [features]
-default = ["abi_unknown"]
-abi_unknown = []
-abi_wasi = []
+default = []
+wasi = ["dep:wasi-stub"]

--- a/examples/test-runner/src/main.rs
+++ b/examples/test-runner/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
         anyhow::bail!("1 argument required: 'rust', 'zig' or 'c'")
     }
     #[cfg(feature = "wasi")]
-    println!("The WASI functions will be stubbed (by `wasi-stub`) for this run");
+    println!("[INFO] The WASI functions will be stubbed (by `wasi-stub`) for this run");
     let plugin_binary = match args[0].as_str() {
         "rust" => {
             println!("=== compiling the Rust plugin");
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
                 .spawn()?
                 .wait()?;
             println!("===");
-            println!("getting wasm from: {}", consts::RUST_PATH);
+            println!("[INFO] getting wasm from: {}", consts::RUST_PATH);
             std::fs::read(consts::RUST_PATH)?
         }
         "zig" => {
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
                 .expect("do you have zig installed and in the path?")
                 .wait()?;
             println!("===");
-            println!("getting wasm from: examples/hello_zig/hello.wasm");
+            println!("[INFO] getting wasm from: examples/hello_zig/hello.wasm");
             std::fs::read("examples/hello_zig/hello.wasm")?
         }
         "c" => {
@@ -78,13 +78,12 @@ fn main() -> Result<()> {
                 .expect("do you have emcc installed and in the path?")
                 .wait()?;
             println!("===");
-            println!("getting wasm from: examples/hello_c/hello.wasm");
+            println!("[INFO] getting wasm from: examples/hello_c/hello.wasm");
             std::fs::read("examples/hello_c/hello.wasm")?
         }
         "-i" | "--input" => {
             custom_run = true;
-            println!("===");
-            println!("getting wasm from: {}", args[1].as_str());
+            println!("[INFO] getting wasm from: {}", args[1].as_str());
             println!(
                 "running func: {}",
                 args.get(2)
@@ -97,7 +96,12 @@ fn main() -> Result<()> {
     };
 
     #[cfg(feature = "wasi")]
-    let plugin_binary = wasi_stub::stub_wasi_functions(&plugin_binary)?;
+    let plugin_binary = {
+        println!("[INFO] Using wasi-stub");
+        let res = wasi_stub::stub_wasi_functions(&plugin_binary)?;
+        println!("[INFO] WASI functions have been stubbed");
+        res
+    };
 
     let mut plugin_instance = PluginInstance::new_from_bytes(plugin_binary).unwrap();
     if custom_run {

--- a/examples/test-runner/src/main.rs
+++ b/examples/test-runner/src/main.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use host_wasmi::PluginInstance;
 
-#[cfg(feature = "abi_unknown")]
+#[cfg(not(feature = "wasi"))]
 mod consts {
     pub const RUST_TARGET: &str = "wasm32-unknown-unknown";
     pub const RUST_PATH: &str =
@@ -14,7 +14,7 @@ mod consts {
     pub const ZIG_TARGET: &str = "wasm32-freestanding";
 }
 
-#[cfg(feature = "abi_wasi")]
+#[cfg(feature = "wasi")]
 mod consts {
     pub const RUST_TARGET: &str = "wasm32-wasi";
     pub const RUST_PATH: &str = "examples/hello_rust/target/wasm32-wasi/debug/hello.wasm";
@@ -27,8 +27,9 @@ fn main() -> Result<()> {
     if args.is_empty() {
         anyhow::bail!("1 argument required: 'rust', 'zig' or 'c'")
     }
+    #[cfg(feature = "wasi")]
+    println!("The WASI functions will be stubbed (by `wasi-stub`) for this run");
     let plugin_binary = match args[0].as_str() {
-        #[cfg(any(feature = "abi_unknown", feature = "abi_wasi"))]
         "rust" => {
             println!("=== compiling the Rust plugin");
             Command::new("cargo")
@@ -42,7 +43,6 @@ fn main() -> Result<()> {
             println!("getting wasm from: {}", consts::RUST_PATH);
             std::fs::read(consts::RUST_PATH)?
         }
-        #[cfg(any(feature = "abi_unknown", feature = "abi_wasi"))]
         "zig" => {
             println!("=== compiling the Zig plugin");
             Command::new("zig")
@@ -62,10 +62,8 @@ fn main() -> Result<()> {
         }
         "c" => {
             println!("=== compiling the C plugin");
-            #[cfg(feature = "abi_unknown")]
-            println!("cfg(abi_unknown) has no effect for C example");
-            #[cfg(feature = "abi_wasi")]
-            println!("cfg(abi_wasi) has no effect for C example");
+            #[cfg(not(feature = "wasi"))]
+            eprintln!("WARNING: the C example should be compiled with `--features wasi`");
 
             println!("{}", std::env::current_dir().unwrap().display());
             Command::new("emcc")
@@ -83,16 +81,7 @@ fn main() -> Result<()> {
             println!("getting wasm from: examples/hello_c/hello.wasm");
             std::fs::read("examples/hello_c/hello.wasm")?
         }
-
-        #[cfg(not(any(feature = "abi_unknown", feature = "abi_wasi")))]
-        "rust" | "zig" => {
-            panic!(
-                "for testing rust or zig, you must enable one feature in [abi_unknown, abi_wasi]"
-            )
-        }
         "-i" | "--input" => {
-            #[cfg(feature = "abi_wasi")]
-            println!("The feature abi_wasi is enabled but the file tested is provided by you.\nThis feature influence how the examples are built, they have no effect here.");
             custom_run = true;
             println!("===");
             println!("getting wasm from: {}", args[1].as_str());
@@ -107,19 +96,28 @@ fn main() -> Result<()> {
         _ => anyhow::bail!("unknown argument '{}'", args[0].as_str()),
     };
 
+    #[cfg(feature = "wasi")]
+    let plugin_binary = wasi_stub::stub_wasi_functions(&plugin_binary)?;
+
     let mut plugin_instance = PluginInstance::new_from_bytes(plugin_binary).unwrap();
     if custom_run {
-        println!(
-            "{:?}",
-            plugin_instance.call(
-                args[2].as_str(),
-                args.iter()
-                    .skip(3)
-                    .map(|x| x.as_bytes())
-                    .collect::<Vec<_>>()
-                    .as_slice()
-            )
-        );
+        let function = args[2].as_str();
+        let args = args
+            .iter()
+            .skip(3)
+            .map(|x| x.as_bytes())
+            .collect::<Vec<_>>();
+        let result = match plugin_instance.call(function, &args) {
+            Ok(res) => res,
+            Err(err) => {
+                eprintln!("Error: {err}");
+                return Ok(());
+            }
+        };
+        match String::from_utf8(result) {
+            Ok(s) => println!("{s}"),
+            Err(_) => panic!("Error: function call '{function}' did not return UTF-8"),
+        }
         return Ok(());
     }
 
@@ -135,7 +133,7 @@ fn main() -> Result<()> {
         let result = match plugin_instance.call(function, args) {
             Ok(res) => res,
             Err(err) => {
-                println!("Error: {err}");
+                eprintln!("Error: {err}");
                 continue;
             }
         };

--- a/wasi-stub/Cargo.toml
+++ b/wasi-stub/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Arnaud Golfouse <arnaud.golfouse@laposte.net>"]
 [dependencies]
 wasm-encoder = "0.29.0"
 wasmparser = "0.107.0"
+thiserror = "1.0"

--- a/wasi-stub/Cargo.toml
+++ b/wasi-stub/Cargo.toml
@@ -5,6 +5,6 @@ version = "0.1.0"
 authors = ["Arnaud Golfouse <arnaud.golfouse@laposte.net>"]
 
 [dependencies]
-wasm-encoder = "0.29.0"
-wasmparser = "0.107.0"
+wasm-encoder = "0.31.0"
+wasmparser = "0.109.0"
 thiserror = "1.0"

--- a/wasi-stub/src/lib.rs
+++ b/wasi-stub/src/lib.rs
@@ -1,0 +1,116 @@
+mod parser_to_encoder;
+
+use self::parser_to_encoder::ParserToEncoder as _;
+use wasmparser::{Import, Payload, Type, TypeRef};
+
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    WasmParser(#[from] wasmparser::BinaryReaderError),
+}
+
+pub fn stub_wasi_functions(binary: &[u8]) -> Result<Vec<u8>, Error> {
+    let parser = wasmparser::Parser::default();
+    wasmparser::validate(binary)?;
+
+    let payloads = parser.parse_all(binary).collect::<Result<Vec<_>, _>>()?;
+
+    let mut result = wasm_encoder::Module::new();
+    let mut types: Vec<Type> = Vec::new();
+    let mut to_stub: Vec<Import> = Vec::new();
+    let mut code_section = wasm_encoder::CodeSection::new();
+    let mut in_code_section = false;
+    let mut after_wasi = 0;
+    // let mut before_wasi = 0; // TODO
+
+    for payload in &payloads {
+        match payload {
+            Payload::TypeSection(type_section) => {
+                types = type_section
+                    .clone()
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()?;
+                let (id, range) = payload.as_section().unwrap();
+                result.section(&wasm_encoder::RawSection {
+                    id,
+                    data: &binary[range],
+                });
+            }
+            Payload::ImportSection(import_section) => {
+                let mut imports = wasm_encoder::ImportSection::new();
+                let mut after_wasi_count = None;
+                for import in import_section.clone() {
+                    let import = import?;
+                    if import.module == "wasi_snapshot_preview1" {
+                        after_wasi_count = Some(0);
+                        to_stub.push(import);
+                    } else {
+                        if let Some(n) = after_wasi_count.as_mut() {
+                            *n += 1;
+                        } else {
+                            // before_wasi += 1;  // TODO
+                        }
+                        imports.import(import.module, import.name, import.ty.convert());
+                    }
+                }
+                after_wasi = after_wasi_count.unwrap_or(0);
+                result.section(&imports);
+            }
+            Payload::FunctionSection(f) => {
+                let mut functions_section = wasm_encoder::FunctionSection::new();
+                for f in &to_stub {
+                    let TypeRef::Func(ty) = f.ty else { continue };
+                    functions_section.function(ty);
+                }
+                for f in f.clone() {
+                    functions_section.function(f?);
+                }
+                result.section(&functions_section);
+            }
+            Payload::CodeSectionStart { .. } => {
+                // TODO: reorder the 'call' instructions in all other functions !
+                if after_wasi > 0 {
+                    panic!("this crate cannot handle 'wasi_preview' imports that happen after other imports")
+                }
+                for f in &to_stub {
+                    println!("found {}::{}: stubbing...", f.module, f.name);
+                    let TypeRef::Func(ty) = f.ty else { continue };
+                    let Type::Func(function_type) = &types[ty as usize] else { continue };
+                    let locals = function_type
+                        .params()
+                        .iter()
+                        .map(|t| (1u32, t.convert()))
+                        .collect::<Vec<_>>();
+
+                    let mut function = wasm_encoder::Function::new(locals);
+                    if function_type.results().is_empty() {
+                        function.instruction(&wasm_encoder::Instruction::End);
+                    } else {
+                        function.instruction(&wasm_encoder::Instruction::I32Const(76));
+                        function.instruction(&wasm_encoder::Instruction::End);
+                    }
+                    code_section.function(&function);
+                }
+                in_code_section = true;
+            }
+            Payload::CodeSectionEntry(function_body) => {
+                code_section.raw(&binary[function_body.range()]);
+            }
+            _ => {
+                if in_code_section {
+                    result.section(&code_section);
+                    in_code_section = false;
+                }
+                if let Some((id, range)) = payload.as_section() {
+                    result.section(&wasm_encoder::RawSection {
+                        id,
+                        data: &binary[range],
+                    });
+                }
+            }
+        };
+    }
+    let result = result.finish();
+    wasmparser::validate(&result)?;
+    Ok(result)
+}

--- a/wasi-stub/src/lib.rs
+++ b/wasi-stub/src/lib.rs
@@ -1,7 +1,7 @@
 mod parser_to_encoder;
 
 use self::parser_to_encoder::ParserToEncoder as _;
-use wasmparser::{Import, Payload, Type, TypeRef};
+use wasmparser::{Import, Payload, StructuralType, SubType, TypeRef};
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
@@ -16,7 +16,7 @@ pub fn stub_wasi_functions(binary: &[u8]) -> Result<Vec<u8>, Error> {
     let payloads = parser.parse_all(binary).collect::<Result<Vec<_>, _>>()?;
 
     let mut result = wasm_encoder::Module::new();
-    let mut types: Vec<Type> = Vec::new();
+    let mut types: Vec<SubType> = Vec::new();
     let mut to_stub: Vec<Import> = Vec::new();
     let mut code_section = wasm_encoder::CodeSection::new();
     let mut in_code_section = false;
@@ -75,7 +75,7 @@ pub fn stub_wasi_functions(binary: &[u8]) -> Result<Vec<u8>, Error> {
                 for f in &to_stub {
                     println!("found {}::{}: stubbing...", f.module, f.name);
                     let TypeRef::Func(ty) = f.ty else { continue };
-                    let Type::Func(function_type) = &types[ty as usize] else { continue };
+                    let StructuralType::Func(function_type) = &types[ty as usize].structural_type else { continue };
                     let locals = function_type
                         .params()
                         .iter()

--- a/wasi-stub/src/main.rs
+++ b/wasi-stub/src/main.rs
@@ -1,9 +1,7 @@
 mod parse_args;
-mod parser_to_encoder;
 
-use self::parser_to_encoder::ParserToEncoder;
 use std::path::PathBuf;
-use wasmparser::{Import, Parser, Payload, Type, TypeRef};
+use wasi_stub::stub_wasi_functions;
 
 // Error handling
 struct Error(Box<dyn std::fmt::Display>);
@@ -25,13 +23,8 @@ fn main() -> Result<(), Error> {
         output_path,
         list,
     } = parse_args::Args::new(std::env::args_os().skip(1))?;
-    let parser = Parser::default();
-    if wasmparser::validate(&binary).is_err() {
-        return Err("Error: the given wasm binary is invalid".into());
-    }
-    let payloads = parser.parse_all(&binary).collect::<Result<Vec<_>, _>>()?;
 
-    let output = process_payloads(&binary, &payloads)?;
+    let output = stub_wasi_functions(&binary)?;
 
     if !list {
         write_output(path, output_path, output)?;
@@ -40,107 +33,6 @@ fn main() -> Result<(), Error> {
     }
 
     Ok(())
-}
-
-fn process_payloads(binary: &[u8], payloads: &[Payload]) -> Result<Vec<u8>, Error> {
-    let mut result = wasm_encoder::Module::new();
-    let mut types: Vec<Type> = Vec::new();
-    let mut to_stub: Vec<Import> = Vec::new();
-    let mut code_section = wasm_encoder::CodeSection::new();
-    let mut in_code_section = false;
-    let mut after_wasi = 0;
-    // let mut before_wasi = 0; // TODO
-
-    for payload in payloads {
-        match payload {
-            Payload::TypeSection(type_section) => {
-                types = type_section
-                    .clone()
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()?;
-                let (id, range) = payload.as_section().unwrap();
-                result.section(&wasm_encoder::RawSection {
-                    id,
-                    data: &binary[range],
-                });
-            }
-            Payload::ImportSection(import_section) => {
-                let mut imports = wasm_encoder::ImportSection::new();
-                let mut after_wasi_count = None;
-                for import in import_section.clone() {
-                    let import = import?;
-                    if import.module == "wasi_snapshot_preview1" {
-                        after_wasi_count = Some(0);
-                        to_stub.push(import);
-                    } else {
-                        if let Some(n) = after_wasi_count.as_mut() {
-                            *n += 1;
-                        } else {
-                            // before_wasi += 1;  // TODO
-                        }
-                        imports.import(import.module, import.name, import.ty.convert());
-                    }
-                }
-                after_wasi = after_wasi_count.unwrap_or(0);
-                result.section(&imports);
-            }
-            Payload::FunctionSection(f) => {
-                let mut functions_section = wasm_encoder::FunctionSection::new();
-                for f in &to_stub {
-                    let TypeRef::Func(ty) = f.ty else { continue };
-                    functions_section.function(ty);
-                }
-                for f in f.clone() {
-                    functions_section.function(f?);
-                }
-                result.section(&functions_section);
-            }
-            Payload::CodeSectionStart { .. } => {
-                // TODO: reorder the 'call' instructions in all other functions !
-                if after_wasi > 0 {
-                    panic!("this crate cannot handle 'wasi_preview' imports that happen after other imports")
-                }
-                for f in &to_stub {
-                    println!("found {}::{}: stubbing...", f.module, f.name);
-                    let TypeRef::Func(ty) = f.ty else { continue };
-                    let Type::Func(function_type) = &types[ty as usize] else { continue };
-                    let locals = function_type
-                        .params()
-                        .iter()
-                        .map(|t| (1u32, t.convert()))
-                        .collect::<Vec<_>>();
-
-                    let mut function = wasm_encoder::Function::new(locals);
-                    if function_type.results().is_empty() {
-                        function.instruction(&wasm_encoder::Instruction::End);
-                    } else {
-                        function.instruction(&wasm_encoder::Instruction::I32Const(76));
-                        function.instruction(&wasm_encoder::Instruction::End);
-                    }
-                    code_section.function(&function);
-                }
-                in_code_section = true;
-            }
-            Payload::CodeSectionEntry(function_body) => {
-                code_section.raw(&binary[function_body.range()]);
-            }
-            _ => {
-                if in_code_section {
-                    result.section(&code_section);
-                    in_code_section = false;
-                }
-                if let Some((id, range)) = payload.as_section() {
-                    result.section(&wasm_encoder::RawSection {
-                        id,
-                        data: &binary[range],
-                    });
-                }
-            }
-        };
-    }
-    let result = result.finish();
-    wasmparser::validate(&result)?;
-    Ok(result)
 }
 
 fn write_output(path: PathBuf, output_path: Option<PathBuf>, output: Vec<u8>) -> Result<(), Error> {


### PR DESCRIPTION
When using `host-wasmi` and wasi, stub all wasi functions with `wasi-stub`.

Also slightly rework the features to make this a bit more ergonomic (see the README).