### PR TITLE
Avoid copy when the plugin returns

### DIFF
--- a/examples/hello_c/hello.c
+++ b/examples/hello_c/hello.c
@@ -4,23 +4,37 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #define PROTOCOL_FUNCTION __attribute__((import_module("typst_env"))) extern "C"
 #else
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #define PROTOCOL_FUNCTION __attribute__((import_module("typst_env"))) extern
 #endif
+
+// ===
+// Functions for the protocol
 
 PROTOCOL_FUNCTION void
 wasm_minimal_protocol_send_result_to_host(const uint8_t *ptr, size_t len);
 PROTOCOL_FUNCTION void wasm_minimal_protocol_write_args_to_buffer(uint8_t *ptr);
 
+EMSCRIPTEN_KEEPALIVE void wasm_minimal_protocol_free_byte_buffer(uint8_t *ptr,
+                                                                 size_t len) {
+  free(ptr);
+}
+
+// ===
+
 EMSCRIPTEN_KEEPALIVE
 int32_t hello(void) {
-  const char message[] = "Hello world !";
-  wasm_minimal_protocol_send_result_to_host((uint8_t *)message,
-                                            sizeof(message) - 1);
+  const char static_message[] = "Hello world !";
+  const size_t length = sizeof(static_message);
+  char *message = malloc(length);
+  memcpy((void *)message, (void *)static_message, length);
+  wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 0;
 }
 
@@ -36,7 +50,6 @@ int32_t double_it(size_t arg_len) {
     alloc_result[arg_len + i] = alloc_result[i];
   }
   wasm_minimal_protocol_send_result_to_host(alloc_result, result_len);
-  free(alloc_result);
   return 0;
 }
 
@@ -66,7 +79,6 @@ int32_t concatenate(size_t arg1_len, size_t arg2_len) {
 
   wasm_minimal_protocol_send_result_to_host(result, total_len + 1);
 
-  free(result);
   free(args);
   return 0;
 }
@@ -102,24 +114,27 @@ int32_t shuffle(size_t arg1_len, size_t arg2_len, size_t arg3_len) {
 
   wasm_minimal_protocol_send_result_to_host(result, result_len);
 
-  free(result);
   free(args);
   return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE
 int32_t returns_ok() {
-  const char message[] = "This is an `Ok`";
-  wasm_minimal_protocol_send_result_to_host((uint8_t *)message,
-                                            sizeof(message) - 1);
+  const char static_message[] = "This is an `Ok`";
+  const size_t length = sizeof(static_message);
+  char *message = malloc(length);
+  memcpy((void *)message, (void *)static_message, length);
+  wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE
 int32_t returns_err() {
-  const char message[] = "This is an `Err`";
-  wasm_minimal_protocol_send_result_to_host((uint8_t *)message,
-                                            sizeof(message) - 1);
+  const char static_message[] = "This is an `Err`";
+  const size_t length = sizeof(static_message);
+  char *message = malloc(length);
+  memcpy((void *)message, (void *)static_message, length);
+  wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 1;
 }
 

--- a/examples/host-wasmi/src/lib.rs
+++ b/examples/host-wasmi/src/lib.rs
@@ -51,34 +51,6 @@ impl PluginInstance {
                 },
             )
             .unwrap()
-            // hack to accept wasi file
-            // https://github.com/near/wasi-stub is preferred
-            /*
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "fd_write",
-                |_: i32, _: i32, _: i32, _: i32| 0i32,
-            )
-            .unwrap()
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "environ_get",
-                |_: i32, _: i32| 0i32,
-            )
-            .unwrap()
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "environ_sizes_get",
-                |_: i32, _: i32| 0i32,
-            )
-            .unwrap()
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "proc_exit",
-                |_: i32| {},
-            )
-            .unwrap()
-            */
             .instantiate(&mut store, &module)
             .map_err(|e| format!("{e}"))?
             .start(&mut store)

--- a/examples/test-runner/src/main.rs
+++ b/examples/test-runner/src/main.rs
@@ -2,9 +2,8 @@
 // you need to build the hello example first
 
 use anyhow::Result;
-use std::process::Command;
-
 use host_wasmi::PluginInstance;
+use std::process::Command;
 
 #[cfg(not(feature = "wasi"))]
 mod consts {
@@ -118,7 +117,7 @@ fn main() -> Result<()> {
                 return Ok(());
             }
         };
-        match String::from_utf8(result) {
+        match std::str::from_utf8(result.get()) {
             Ok(s) => println!("{s}"),
             Err(_) => panic!("Error: function call '{function}' did not return UTF-8"),
         }
@@ -141,7 +140,7 @@ fn main() -> Result<()> {
                 continue;
             }
         };
-        match String::from_utf8(result) {
+        match std::str::from_utf8(result.get()) {
             Ok(s) => println!("{s}"),
             Err(_) => panic!("Error: function call '{function}' did not return UTF-8"),
         }

--- a/protocol.md
+++ b/protocol.md
@@ -18,23 +18,33 @@ Valid plugins need to import two functions (that will be provided by the runtime
 
   Write the arguments for the current function into the buffer pointed at by `ptr`.
 
-  Each function for the protocol receives lengths as its arguments (see [Exported functions](#exported-functions)). The capacity of the buffer pointed at by `ptr` should be at least the sum of all those lengths.
+  Each function for the protocol receives lengths as its arguments (see [User-defined functions](#user-defined-functions)). The capacity of the buffer pointed at by `ptr` should be at least the sum of all those lengths.
 
 - `(import "typst_env" "wasm_minimal_protocol_send_result_to_host" (func (param i32 i32)))`
 
   The first parameter is a pointer to a buffer (`ptr`), the second is the length of the buffer (`len`).
 
-  Reads `len` bytes pointed at by `ptr` into host memory. The memory pointed at by `ptr` can be freed immediately after this function returns.
+  Send `len` and `ptr` to host memory. The buffer must not be freed by the end of the function: it will be freed by the runtime by calling [`wasm_minimal_protocol_send_result_to_host`](#exports).
 
-  If the message should be interpreted as an error message (see [Exported functions](#exported-functions)), it should be encoded as UTF-8.
+  If the message should be interpreted as an error message (see [User-defined functions](#user-defined-functions)), it should be encoded as UTF-8.
 
-# Exported functions
+  ### Note
+
+  If [`wasm_minimal_protocol_send_result_to_host`](#exports) calls `free` (or a similar routine), be careful that the buffer does not point to static memory.
+
+# Exports
+
+Valid plugins need to export a function named `wasm_minimal_protocol_send_result_to_host`, that has signature `func (param i32 i32)`.
+
+This function will be used by the runtime to free the block of memory returned by a [user-defined](#user-defined-functions) function.
+
+# User-defined functions
 
 To conform to the protocol, an exported function should:
 
-- Take `n` arguments `a₁`, `a₂`, ..., `aₙ` of type `u32` (interpreted as lengths, so `usize/size_t` may be preferable), and return one `i32`.
+- Take `n` arguments `a₁`, `a₂`, ..., `aₙ` of type `u32` (interpreted as lengths, so `usize/size_t` may be preferable), and return one `i32`. We will call the return `return_code`.
 - The function should first allocate a buffer `buf` of length `a₁ + a₂ + ⋯ + aₙ`, and call `wasm_minimal_protocol_write_args_to_buffer(buf.ptr)`.
 - The `a₁` first bytes of the buffer constitute the first argument, the `a₂` next bytes the second argument, and so on.
 - Before returning, the function should call `wasm_minimal_protocol_send_result_to_host` to send its result back to the host.
-- To signal success, the function should return `0`.
-- To signal an error, the function should return `1`. The written buffer is then interpreted as an error message.
+- To signal success, `return_code` must be `0`.
+- To signal an error, `return_code` must be `1`. The sent buffer is then interpreted as an error message, and must be encoded as UTF-8.


### PR DESCRIPTION
This should avoid copying the data until another function is called.