### PR TITLE
Tests

### DIFF
--- a/examples/hello_c/hello.c
+++ b/examples/hello_c/hello.c
@@ -4,23 +4,37 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #define PROTOCOL_FUNCTION __attribute__((import_module("typst_env"))) extern "C"
 #else
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #define PROTOCOL_FUNCTION __attribute__((import_module("typst_env"))) extern
 #endif
+
+// ===
+// Functions for the protocol
 
 PROTOCOL_FUNCTION void
 wasm_minimal_protocol_send_result_to_host(const uint8_t *ptr, size_t len);
 PROTOCOL_FUNCTION void wasm_minimal_protocol_write_args_to_buffer(uint8_t *ptr);
 
+EMSCRIPTEN_KEEPALIVE void wasm_minimal_protocol_free_byte_buffer(uint8_t *ptr,
+                                                                 size_t len) {
+  free(ptr);
+}
+
+// ===
+
 EMSCRIPTEN_KEEPALIVE
 int32_t hello(void) {
-  const char message[] = "Hello world !";
-  wasm_minimal_protocol_send_result_to_host((uint8_t *)message,
-                                            sizeof(message) - 1);
+  const char static_message[] = "Hello world !";
+  const size_t length = sizeof(static_message);
+  char *message = malloc(length);
+  memcpy((void *)message, (void *)static_message, length);
+  wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 0;
 }
 
@@ -36,7 +50,6 @@ int32_t double_it(size_t arg_len) {
     alloc_result[arg_len + i] = alloc_result[i];
   }
   wasm_minimal_protocol_send_result_to_host(alloc_result, result_len);
-  free(alloc_result);
   return 0;
 }
 
@@ -66,7 +79,6 @@ int32_t concatenate(size_t arg1_len, size_t arg2_len) {
 
   wasm_minimal_protocol_send_result_to_host(result, total_len + 1);
 
-  free(result);
   free(args);
   return 0;
 }
@@ -102,24 +114,27 @@ int32_t shuffle(size_t arg1_len, size_t arg2_len, size_t arg3_len) {
 
   wasm_minimal_protocol_send_result_to_host(result, result_len);
 
-  free(result);
   free(args);
   return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE
 int32_t returns_ok() {
-  const char message[] = "This is an `Ok`";
-  wasm_minimal_protocol_send_result_to_host((uint8_t *)message,
-                                            sizeof(message) - 1);
+  const char static_message[] = "This is an `Ok`";
+  const size_t length = sizeof(static_message);
+  char *message = malloc(length);
+  memcpy((void *)message, (void *)static_message, length);
+  wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE
 int32_t returns_err() {
-  const char message[] = "This is an `Err`";
-  wasm_minimal_protocol_send_result_to_host((uint8_t *)message,
-                                            sizeof(message) - 1);
+  const char static_message[] = "This is an `Err`";
+  const size_t length = sizeof(static_message);
+  char *message = malloc(length);
+  memcpy((void *)message, (void *)static_message, length);
+  wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 1;
 }
 

--- a/examples/hello_c/hello.c
+++ b/examples/hello_c/hello.c
@@ -30,7 +30,7 @@ EMSCRIPTEN_KEEPALIVE void wasm_minimal_protocol_free_byte_buffer(uint8_t *ptr,
 
 EMSCRIPTEN_KEEPALIVE
 int32_t hello(void) {
-  const char static_message[] = "Hello world !";
+  const char static_message[] = "Hello from wasm!!!";
   const size_t length = sizeof(static_message);
   char *message = malloc(length);
   memcpy((void *)message, (void *)static_message, length);

--- a/examples/hello_rust/src/lib.rs
+++ b/examples/hello_rust/src/lib.rs
@@ -9,7 +9,7 @@ pub fn hello() -> Vec<u8> {
 
 #[wasm_func]
 pub fn double_it(arg: &[u8]) -> Vec<u8> {
-    [arg, b".", arg].concat()
+    [arg, arg].concat()
 }
 
 #[wasm_func]

--- a/examples/hello_zig/hello.zig
+++ b/examples/hello_zig/hello.zig
@@ -17,7 +17,7 @@ export fn wasm_minimal_protocol_free_byte_buffer(ptr: [*]u8, len: usize) void {
 // ===
 
 export fn hello() i32 {
-    const message = "Hello world !";
+    const message = "Hello from wasm!!!";
     var result = allocator.alloc(u8, message.len) catch return 1;
     @memcpy(result, message);
     wasm_minimal_protocol_send_result_to_host(result.ptr, result.len);

--- a/examples/host-wasmi/src/lib.rs
+++ b/examples/host-wasmi/src/lib.rs
@@ -51,34 +51,6 @@ impl PluginInstance {
                 },
             )
             .unwrap()
-            // hack to accept wasi file
-            // https://github.com/near/wasi-stub is preferred
-            /*
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "fd_write",
-                |_: i32, _: i32, _: i32, _: i32| 0i32,
-            )
-            .unwrap()
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "environ_get",
-                |_: i32, _: i32| 0i32,
-            )
-            .unwrap()
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "environ_sizes_get",
-                |_: i32, _: i32| 0i32,
-            )
-            .unwrap()
-            .func_wrap(
-                "wasi_snapshot_preview1",
-                "proc_exit",
-                |_: i32| {},
-            )
-            .unwrap()
-            */
             .instantiate(&mut store, &module)
             .map_err(|e| format!("{e}"))?
             .start(&mut store)

--- a/examples/test-runner/Cargo.toml
+++ b/examples/test-runner/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 anyhow = "1.0.71"
 cfg-if = "1.0.0"
 host-wasmi = { path = "../host-wasmi" }
-wasi-stub = { path = "../../wasi-stub", optional = true }
+wasi-stub = { path = "../../wasi-stub" }
 
 
 [features]
 default = []
-wasi = ["dep:wasi-stub"]
+wasi = []

--- a/examples/test-runner/src/main.rs
+++ b/examples/test-runner/src/main.rs
@@ -2,9 +2,8 @@
 // you need to build the hello example first
 
 use anyhow::Result;
-use std::process::Command;
-
 use host_wasmi::PluginInstance;
+use std::process::Command;
 
 #[cfg(not(feature = "wasi"))]
 mod consts {
@@ -118,7 +117,7 @@ fn main() -> Result<()> {
                 return Ok(());
             }
         };
-        match String::from_utf8(result) {
+        match std::str::from_utf8(result.get()) {
             Ok(s) => println!("{s}"),
             Err(_) => panic!("Error: function call '{function}' did not return UTF-8"),
         }
@@ -141,7 +140,7 @@ fn main() -> Result<()> {
                 continue;
             }
         };
-        match String::from_utf8(result) {
+        match std::str::from_utf8(result.get()) {
             Ok(s) => println!("{s}"),
             Err(_) => panic!("Error: function call '{function}' did not return UTF-8"),
         }

--- a/examples/test-runner/src/main.rs
+++ b/examples/test-runner/src/main.rs
@@ -85,12 +85,8 @@ fn main() -> Result<()> {
     let mut plugin_instance = PluginInstance::new_from_bytes(plugin_binary).unwrap();
     if custom_run {
         let function = args[2].as_str();
-        let args = args
-            .iter()
-            .skip(3)
-            .map(|x| x.as_bytes())
-            .collect::<Vec<_>>();
-        let result = match plugin_instance.call(function, &args) {
+        let args = args.iter().skip(3).map(|x| x.as_bytes());
+        let result = match plugin_instance.call(function, args) {
             Ok(res) => res,
             Err(err) => {
                 eprintln!("Error: {err}");
@@ -113,7 +109,7 @@ fn main() -> Result<()> {
         ("returns_err", &[]),
         ("will_panic", &[]),
     ] {
-        let result = match plugin_instance.call(function, args) {
+        let result = match plugin_instance.call(function, args.iter().copied()) {
             Ok(res) => res,
             Err(err) => {
                 eprintln!("Error: {err}");
@@ -202,7 +198,7 @@ mod tests {
         function: &str,
         args: &[&[u8]],
     ) -> Result<String, String> {
-        match plugin_instance.call(function, args) {
+        match plugin_instance.call(function, args.iter().copied()) {
             Ok(res) => match std::str::from_utf8(res.get()) {
                 Ok(s) => Ok(s.to_owned()),
                 Err(_) => panic!("Error: function call '{function}' did not return UTF-8"),

--- a/examples/test-runner/src/main.rs
+++ b/examples/test-runner/src/main.rs
@@ -3,22 +3,18 @@
 
 use anyhow::Result;
 use host_wasmi::PluginInstance;
-use std::process::Command;
+use std::{path::Path, process::Command};
 
-#[cfg(not(feature = "wasi"))]
-mod consts {
-    pub const RUST_TARGET: &str = "wasm32-unknown-unknown";
-    pub const RUST_PATH: &str =
-        "examples/hello_rust/target/wasm32-unknown-unknown/debug/hello.wasm";
-    pub const ZIG_TARGET: &str = "wasm32-freestanding";
-}
-
-#[cfg(feature = "wasi")]
-mod consts {
-    pub const RUST_TARGET: &str = "wasm32-wasi";
-    pub const RUST_PATH: &str = "examples/hello_rust/target/wasm32-wasi/debug/hello.wasm";
-    pub const ZIG_TARGET: &str = "wasm32-wasi";
-}
+const WASI: bool = {
+    #[cfg(feature = "wasi")]
+    {
+        true
+    }
+    #[cfg(not(feature = "wasi"))]
+    {
+        false
+    }
+};
 
 fn main() -> Result<()> {
     let mut custom_run = false;
@@ -26,59 +22,42 @@ fn main() -> Result<()> {
     if args.is_empty() {
         anyhow::bail!("1 argument required: 'rust', 'zig' or 'c'")
     }
-    #[cfg(feature = "wasi")]
-    println!("[INFO] The WASI functions will be stubbed (by `wasi-stub`) for this run");
-    let plugin_binary = match args[0].as_str() {
+    if WASI {
+        println!("[INFO] The WASI functions will be stubbed (by `wasi-stub`) for this run");
+    }
+    let mut plugin_binary = match args[0].as_str() {
         "rust" => {
             println!("=== compiling the Rust plugin");
-            Command::new("cargo")
-                .arg("build")
-                .arg("--target")
-                .arg(consts::RUST_TARGET)
-                .current_dir("examples/hello_rust")
-                .spawn()?
-                .wait()?;
+            let result = compile_rust(WASI, ".")?;
             println!("===");
-            println!("[INFO] getting wasm from: {}", consts::RUST_PATH);
-            std::fs::read(consts::RUST_PATH)?
+            println!(
+                "[INFO] getting wasm from: {}",
+                if WASI {
+                    "examples/hello_rust/target/wasm32-wasi/debug/hello.wasm"
+                } else {
+                    "examples/hello_rust/target/wasm32-unknown-unknown/debug/hello.wasm"
+                }
+            );
+            result
         }
         "zig" => {
             println!("=== compiling the Zig plugin");
-            Command::new("zig")
-                .arg("build-lib")
-                .arg("hello.zig")
-                .arg("-target")
-                .arg(consts::ZIG_TARGET)
-                .arg("-dynamic")
-                .arg("-rdynamic")
-                .current_dir("examples/hello_zig")
-                .spawn()
-                .expect("do you have zig installed and in the path?")
-                .wait()?;
+            let result = compile_zig(WASI, ".")?;
             println!("===");
             println!("[INFO] getting wasm from: examples/hello_zig/hello.wasm");
-            std::fs::read("examples/hello_zig/hello.wasm")?
+            result
         }
         "c" => {
             println!("=== compiling the C plugin");
-            #[cfg(not(feature = "wasi"))]
-            eprintln!("WARNING: the C example should be compiled with `--features wasi`");
+            if !WASI {
+                eprintln!("WARNING: the C example should be compiled with `--features wasi`");
+            }
 
             println!("{}", std::env::current_dir().unwrap().display());
-            Command::new("emcc")
-                .arg("--no-entry")
-                .arg("-s")
-                .arg("ERROR_ON_UNDEFINED_SYMBOLS=0")
-                .arg("-o")
-                .arg("hello.wasm")
-                .arg("hello.c")
-                .current_dir("examples/hello_c/")
-                .spawn()
-                .expect("do you have emcc installed and in the path?")
-                .wait()?;
+            let result = compile_c(".")?;
             println!("===");
             println!("[INFO] getting wasm from: examples/hello_c/hello.wasm");
-            std::fs::read("examples/hello_c/hello.wasm")?
+            result
         }
         "-i" | "--input" => {
             custom_run = true;
@@ -94,13 +73,14 @@ fn main() -> Result<()> {
         _ => anyhow::bail!("unknown argument '{}'", args[0].as_str()),
     };
 
-    #[cfg(feature = "wasi")]
-    let plugin_binary = {
-        println!("[INFO] Using wasi-stub");
-        let res = wasi_stub::stub_wasi_functions(&plugin_binary)?;
-        println!("[INFO] WASI functions have been stubbed");
-        res
-    };
+    if WASI {
+        plugin_binary = {
+            println!("[INFO] Using wasi-stub");
+            let res = wasi_stub::stub_wasi_functions(&plugin_binary)?;
+            println!("[INFO] WASI functions have been stubbed");
+            res
+        };
+    }
 
     let mut plugin_instance = PluginInstance::new_from_bytes(plugin_binary).unwrap();
     if custom_run {
@@ -147,4 +127,188 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn compile_rust(wasi: bool, dir_root: &str) -> Result<Vec<u8>> {
+    let target = if wasi {
+        "wasm32-wasi"
+    } else {
+        "wasm32-unknown-unknown"
+    };
+    Command::new("cargo")
+        .arg("build")
+        .arg("--target")
+        .arg(target)
+        .current_dir(Path::new(dir_root).join("examples/hello_rust"))
+        .spawn()
+        .map_err(|err| anyhow::format_err!("while spawning the build command: {err}"))?
+        .wait()?;
+    let path = Path::new(dir_root).join(format!(
+        "examples/hello_rust/target/{target}/debug/hello.wasm"
+    ));
+    std::fs::read(&path)
+        .map_err(|err| anyhow::format_err!("while reading {}: {err}", path.display()))
+}
+
+fn compile_zig(wasi: bool, dir_root: &str) -> Result<Vec<u8>> {
+    Command::new("zig")
+        .arg("build-lib")
+        .arg("hello.zig")
+        .arg("-target")
+        .arg(if wasi {
+            "wasm32-wasi"
+        } else {
+            "wasm32-freestanding"
+        })
+        .arg("-dynamic")
+        .arg("-rdynamic")
+        .current_dir(Path::new(dir_root).join("examples/hello_zig"))
+        .spawn()
+        .expect("do you have zig installed and in the path?")
+        .wait()?;
+    let path = Path::new(dir_root).join("examples/hello_zig/hello.wasm");
+    std::fs::read(&path)
+        .map_err(|err| anyhow::format_err!("while reading {}: {err}", path.display()))
+}
+
+fn compile_c(dir_root: &str) -> Result<Vec<u8>> {
+    Command::new("emcc")
+        .arg("--no-entry")
+        .arg("-s")
+        .arg("ERROR_ON_UNDEFINED_SYMBOLS=0")
+        .arg("-o")
+        .arg("hello.wasm")
+        .arg("hello.c")
+        .current_dir(Path::new(dir_root).join("examples/hello_c/"))
+        .spawn()
+        .expect("do you have emcc installed and in the path?")
+        .wait()?;
+    let path = Path::new(dir_root).join("examples/hello_c/hello.wasm");
+    std::fs::read(&path)
+        .map_err(|err| anyhow::format_err!("while reading {}: {err}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Needed to avoid tests walking all over each others.
+    static LOCK: Mutex<()> = Mutex::new(());
+    const ROOT_DIR: &str = "../..";
+
+    fn run_function(
+        plugin_instance: &mut PluginInstance,
+        function: &str,
+        args: &[&[u8]],
+    ) -> Result<String, String> {
+        match plugin_instance.call(function, args) {
+            Ok(res) => match std::str::from_utf8(res.get()) {
+                Ok(s) => Ok(s.to_owned()),
+                Err(_) => panic!("Error: function call '{function}' did not return UTF-8"),
+            },
+            Err(err) => Err(err),
+        }
+    }
+
+    fn test_default_functions(plugin_instance: &mut PluginInstance) -> bool {
+        let mut all_passed = true;
+        for (function, args, expected) in [
+            ("hello", &[] as &[&[u8]], Ok("Hello from wasm!!!")),
+            ("double_it", &[b"double me!!"], Ok("double me!!double me!!")),
+            ("concatenate", &[b"val1", b"value2"], Ok("val1*value2")),
+            (
+                "shuffle",
+                &[b"value1", b"value2", b"value3"],
+                Ok("value3-value1-value2"),
+            ),
+            ("returns_ok", &[], Ok("This is an `Ok`")),
+            (
+                "returns_err",
+                &[],
+                Err("plugin errored with: 'This is an `Err`'"),
+            ),
+            ("will_panic", &[], Err("plugin panicked")),
+        ] {
+            let res = run_function(plugin_instance, function, args);
+            let res = res.as_ref().map(|s| s.as_str()).map_err(|s| s.as_str());
+            if expected != res {
+                all_passed = false;
+                eprintln!("Incorrect result when calling {}:", function);
+                eprintln!("  - expected: {:?}", expected);
+                eprintln!("  - got: {:?}", res);
+            } else {
+                println!("calling {function} returned: {:?}", res)
+            }
+        }
+        all_passed
+    }
+
+    #[test]
+    fn rust_no_wasi() -> Result<()> {
+        let lock = LOCK.lock();
+        let binary = compile_rust(false, ROOT_DIR)?;
+        drop(lock);
+        let mut plugin_instance = PluginInstance::new_from_bytes(binary).unwrap();
+        if !test_default_functions(&mut plugin_instance) {
+            anyhow::bail!("Some incorrect result detected");
+        } else {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn rust_wasi() -> Result<()> {
+        let lock = LOCK.lock();
+        let binary = compile_rust(true, ROOT_DIR)?;
+        drop(lock);
+        let binary = wasi_stub::stub_wasi_functions(&binary)?;
+        let mut plugin_instance = PluginInstance::new_from_bytes(binary).unwrap();
+        if !test_default_functions(&mut plugin_instance) {
+            anyhow::bail!("Some incorrect result detected");
+        } else {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn zig_no_wasi() -> Result<()> {
+        let lock = LOCK.lock();
+        let binary = compile_zig(false, ROOT_DIR)?;
+        drop(lock);
+        let mut plugin_instance = PluginInstance::new_from_bytes(binary).unwrap();
+        if !test_default_functions(&mut plugin_instance) {
+            anyhow::bail!("Some incorrect result detected");
+        } else {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn zig_wasi() -> Result<()> {
+        let lock = LOCK.lock();
+        let binary = compile_zig(true, ROOT_DIR)?;
+        drop(lock);
+        let binary = wasi_stub::stub_wasi_functions(&binary)?;
+        let mut plugin_instance = PluginInstance::new_from_bytes(binary).unwrap();
+        if !test_default_functions(&mut plugin_instance) {
+            anyhow::bail!("Some incorrect result detected");
+        } else {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn c_wasi() -> Result<()> {
+        let lock = LOCK.lock();
+        let binary = compile_c(ROOT_DIR)?;
+        drop(lock);
+        let binary = wasi_stub::stub_wasi_functions(&binary)?;
+        let mut plugin_instance = PluginInstance::new_from_bytes(binary).unwrap();
+        if !test_default_functions(&mut plugin_instance) {
+            anyhow::bail!("Some incorrect result detected");
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/protocol.md
+++ b/protocol.md
@@ -18,23 +18,33 @@ Valid plugins need to import two functions (that will be provided by the runtime
 
   Write the arguments for the current function into the buffer pointed at by `ptr`.
 
-  Each function for the protocol receives lengths as its arguments (see [Exported functions](#exported-functions)). The capacity of the buffer pointed at by `ptr` should be at least the sum of all those lengths.
+  Each function for the protocol receives lengths as its arguments (see [User-defined functions](#user-defined-functions)). The capacity of the buffer pointed at by `ptr` should be at least the sum of all those lengths.
 
 - `(import "typst_env" "wasm_minimal_protocol_send_result_to_host" (func (param i32 i32)))`
 
   The first parameter is a pointer to a buffer (`ptr`), the second is the length of the buffer (`len`).
 
-  Reads `len` bytes pointed at by `ptr` into host memory. The memory pointed at by `ptr` can be freed immediately after this function returns.
+  Send `len` and `ptr` to host memory. The buffer must not be freed by the end of the function: it will be freed by the runtime by calling [`wasm_minimal_protocol_send_result_to_host`](#exports).
 
-  If the message should be interpreted as an error message (see [Exported functions](#exported-functions)), it should be encoded as UTF-8.
+  If the message should be interpreted as an error message (see [User-defined functions](#user-defined-functions)), it should be encoded as UTF-8.
 
-# Exported functions
+  ### Note
+
+  If [`wasm_minimal_protocol_send_result_to_host`](#exports) calls `free` (or a similar routine), be careful that the buffer does not point to static memory.
+
+# Exports
+
+Valid plugins need to export a function named `wasm_minimal_protocol_send_result_to_host`, that has signature `func (param i32 i32)`.
+
+This function will be used by the runtime to free the block of memory returned by a [user-defined](#user-defined-functions) function.
+
+# User-defined functions
 
 To conform to the protocol, an exported function should:
 
-- Take `n` arguments `a₁`, `a₂`, ..., `aₙ` of type `u32` (interpreted as lengths, so `usize/size_t` may be preferable), and return one `i32`.
+- Take `n` arguments `a₁`, `a₂`, ..., `aₙ` of type `u32` (interpreted as lengths, so `usize/size_t` may be preferable), and return one `i32`. We will call the return `return_code`.
 - The function should first allocate a buffer `buf` of length `a₁ + a₂ + ⋯ + aₙ`, and call `wasm_minimal_protocol_write_args_to_buffer(buf.ptr)`.
 - The `a₁` first bytes of the buffer constitute the first argument, the `a₂` next bytes the second argument, and so on.
 - Before returning, the function should call `wasm_minimal_protocol_send_result_to_host` to send its result back to the host.
-- To signal success, the function should return `0`.
-- To signal an error, the function should return `1`. The written buffer is then interpreted as an error message.
+- To signal success, `return_code` must be `0`.
+- To signal an error, `return_code` must be `1`. The sent buffer is then interpreted as an error message, and must be encoded as UTF-8.


### PR DESCRIPTION
(To be merged after #13)

Add tests for easier development: just run `cargo test` to automatically test that all examples return the correct strings.

Also add some improvements:
- Errors are handled a bit better
- The args are passed by iterator (so no need to collect them before)