### PR TITLE
Use the version of the protocol used by typst

### DIFF
--- a/examples/hello_c/hello.c
+++ b/examples/hello_c/hello.c
@@ -21,19 +21,12 @@ PROTOCOL_FUNCTION void
 wasm_minimal_protocol_send_result_to_host(const uint8_t *ptr, size_t len);
 PROTOCOL_FUNCTION void wasm_minimal_protocol_write_args_to_buffer(uint8_t *ptr);
 
-EMSCRIPTEN_KEEPALIVE void wasm_minimal_protocol_free_byte_buffer(uint8_t *ptr,
-                                                                 size_t len) {
-  free(ptr);
-}
-
 // ===
 
 EMSCRIPTEN_KEEPALIVE
 int32_t hello(void) {
-  const char static_message[] = "Hello from wasm!!!";
-  const size_t length = sizeof(static_message);
-  char *message = malloc(length);
-  memcpy((void *)message, (void *)static_message, length);
+  const char message[] = "Hello from wasm!!!";
+  const size_t length = sizeof(message);
   wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 0;
 }
@@ -41,15 +34,16 @@ int32_t hello(void) {
 EMSCRIPTEN_KEEPALIVE
 int32_t double_it(size_t arg_len) {
   size_t result_len = arg_len * 2;
-  uint8_t *alloc_result = (uint8_t *)malloc(result_len);
-  if (alloc_result == NULL) {
+  uint8_t *result = (uint8_t *)malloc(result_len);
+  if (result == NULL) {
     return 1;
   }
-  wasm_minimal_protocol_write_args_to_buffer(alloc_result);
+  wasm_minimal_protocol_write_args_to_buffer(result);
   for (size_t i = 0; i < arg_len; i++) {
-    alloc_result[arg_len + i] = alloc_result[i];
+    result[arg_len + i] = result[i];
   }
-  wasm_minimal_protocol_send_result_to_host(alloc_result, result_len);
+  wasm_minimal_protocol_send_result_to_host(result, result_len);
+  free(result);
   return 0;
 }
 
@@ -79,6 +73,7 @@ int32_t concatenate(size_t arg1_len, size_t arg2_len) {
 
   wasm_minimal_protocol_send_result_to_host(result, total_len + 1);
 
+  free(result);
   free(args);
   return 0;
 }
@@ -114,26 +109,23 @@ int32_t shuffle(size_t arg1_len, size_t arg2_len, size_t arg3_len) {
 
   wasm_minimal_protocol_send_result_to_host(result, result_len);
 
+  free(result);
   free(args);
   return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE
 int32_t returns_ok() {
-  const char static_message[] = "This is an `Ok`";
-  const size_t length = sizeof(static_message);
-  char *message = malloc(length);
-  memcpy((void *)message, (void *)static_message, length);
+  const char message[] = "This is an `Ok`";
+  const size_t length = sizeof(message);
   wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 0;
 }
 
 EMSCRIPTEN_KEEPALIVE
 int32_t returns_err() {
-  const char static_message[] = "This is an `Err`";
-  const size_t length = sizeof(static_message);
-  char *message = malloc(length);
-  memcpy((void *)message, (void *)static_message, length);
+  const char message[] = "This is an `Err`";
+  const size_t length = sizeof(message);
   wasm_minimal_protocol_send_result_to_host((uint8_t *)message, length - 1);
   return 1;
 }

--- a/examples/hello_zig/hello.zig
+++ b/examples/hello_zig/hello.zig
@@ -7,25 +7,17 @@ const allocator = std.heap.page_allocator;
 extern "typst_env" fn wasm_minimal_protocol_send_result_to_host(ptr: [*]const u8, len: usize) void;
 extern "typst_env" fn wasm_minimal_protocol_write_args_to_buffer(ptr: [*]u8) void;
 
-export fn wasm_minimal_protocol_free_byte_buffer(ptr: [*]u8, len: usize) void {
-    var slice: []u8 = undefined;
-    slice.ptr = ptr;
-    slice.len = len;
-    allocator.free(slice);
-}
-
 // ===
 
 export fn hello() i32 {
     const message = "Hello from wasm!!!";
-    var result = allocator.alloc(u8, message.len) catch return 1;
-    @memcpy(result, message);
-    wasm_minimal_protocol_send_result_to_host(result.ptr, result.len);
+    wasm_minimal_protocol_send_result_to_host(message.ptr, message.len);
     return 0;
 }
 
 export fn double_it(arg1_len: usize) i32 {
     var result = allocator.alloc(u8, arg1_len * 2) catch return 1;
+    defer allocator.free(result);
     wasm_minimal_protocol_write_args_to_buffer(result.ptr);
     for (0..arg1_len) |i| {
         result[i + arg1_len] = result[i];
@@ -40,6 +32,7 @@ export fn concatenate(arg1_len: usize, arg2_len: usize) i32 {
     wasm_minimal_protocol_write_args_to_buffer(args.ptr);
 
     var result = allocator.alloc(u8, arg1_len + arg2_len + 1) catch return 1;
+    defer allocator.free(result);
     for (0..arg1_len) |i| {
         result[i] = args[i];
     }
@@ -62,6 +55,7 @@ export fn shuffle(arg1_len: usize, arg2_len: usize, arg3_len: usize) i32 {
     var arg3 = args[arg1_len + arg2_len .. args.len];
 
     var result = allocator.alloc(u8, arg1_len + arg2_len + arg3_len + 2) catch return 1;
+    defer allocator.free(result);
     @memcpy(result[0..arg3.len], arg3);
     result[arg3.len] = '-';
     @memcpy(result[arg3.len + 1 ..][0..arg1.len], arg1);
@@ -74,17 +68,13 @@ export fn shuffle(arg1_len: usize, arg2_len: usize, arg3_len: usize) i32 {
 
 export fn returns_ok() i32 {
     const message = "This is an `Ok`";
-    var result = allocator.alloc(u8, message.len) catch return 1;
-    @memcpy(result, message);
-    wasm_minimal_protocol_send_result_to_host(result.ptr, result.len);
+    wasm_minimal_protocol_send_result_to_host(message.ptr, message.len);
     return 0;
 }
 
 export fn returns_err() i32 {
     const message = "This is an `Err`";
-    var result = allocator.alloc(u8, message.len) catch return 1;
-    @memcpy(result, message);
-    wasm_minimal_protocol_send_result_to_host(result.ptr, result.len);
+    wasm_minimal_protocol_send_result_to_host(message.ptr, message.len);
     return 1;
 }
 

--- a/protocol.md
+++ b/protocol.md
@@ -18,33 +18,23 @@ Valid plugins need to import two functions (that will be provided by the runtime
 
   Write the arguments for the current function into the buffer pointed at by `ptr`.
 
-  Each function for the protocol receives lengths as its arguments (see [User-defined functions](#user-defined-functions)). The capacity of the buffer pointed at by `ptr` should be at least the sum of all those lengths.
+  Each function for the protocol receives lengths as its arguments (see [Exported functions](#exported-functions)). The capacity of the buffer pointed at by `ptr` should be at least the sum of all those lengths.
 
 - `(import "typst_env" "wasm_minimal_protocol_send_result_to_host" (func (param i32 i32)))`
 
   The first parameter is a pointer to a buffer (`ptr`), the second is the length of the buffer (`len`).
 
-  Send `len` and `ptr` to host memory. The buffer must not be freed by the end of the function: it will be freed by the runtime by calling [`wasm_minimal_protocol_send_result_to_host`](#exports).
+  Reads `len` bytes pointed at by `ptr` into host memory. The memory pointed at by `ptr` can be freed immediately after this function returns.
 
-  If the message should be interpreted as an error message (see [User-defined functions](#user-defined-functions)), it should be encoded as UTF-8.
+  If the message should be interpreted as an error message (see [Exported functions](#exported-functions)), it should be encoded as UTF-8.
 
-  ### Note
-
-  If [`wasm_minimal_protocol_send_result_to_host`](#exports) calls `free` (or a similar routine), be careful that the buffer does not point to static memory.
-
-# Exports
-
-Valid plugins need to export a function named `wasm_minimal_protocol_send_result_to_host`, that has signature `func (param i32 i32)`.
-
-This function will be used by the runtime to free the block of memory returned by a [user-defined](#user-defined-functions) function.
-
-# User-defined functions
+# Exported functions
 
 To conform to the protocol, an exported function should:
 
-- Take `n` arguments `a₁`, `a₂`, ..., `aₙ` of type `u32` (interpreted as lengths, so `usize/size_t` may be preferable), and return one `i32`. We will call the return `return_code`.
+- Take `n` arguments `a₁`, `a₂`, ..., `aₙ` of type `u32` (interpreted as lengths, so `usize/size_t` may be preferable), and return one `i32`.
 - The function should first allocate a buffer `buf` of length `a₁ + a₂ + ⋯ + aₙ`, and call `wasm_minimal_protocol_write_args_to_buffer(buf.ptr)`.
 - The `a₁` first bytes of the buffer constitute the first argument, the `a₂` next bytes the second argument, and so on.
 - Before returning, the function should call `wasm_minimal_protocol_send_result_to_host` to send its result back to the host.
-- To signal success, `return_code` must be `0`.
-- To signal an error, `return_code` must be `1`. The sent buffer is then interpreted as an error message, and must be encoded as UTF-8.
+- To signal success, the function should return `0`.
+- To signal an error, the function should return `1`. The written buffer is then interpreted as an error message, and must be encoded as UTF-8.


### PR DESCRIPTION
This brings us up to date with typst, since https://github.com/typst/typst/pull/1555 was merged.

This reverts to the previous model of the protocol.