### PR TITLE
Remove wasi-stub dependency on anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,6 @@ dependencies = [
 name = "wasi-stub"
 version = "0.2.0"
 dependencies = [
- "anyhow",
  "wasmprinter",
  "wast",
 ]

--- a/crates/wasi-stub/Cargo.toml
+++ b/crates/wasi-stub/Cargo.toml
@@ -5,6 +5,5 @@ version = "0.2.0"
 authors = ["Arnaud Golfouse <arnaud.golfouse@laposte.net>"]
 
 [dependencies]
-anyhow = "1.0"
 wast = "65.0"
 wasmprinter = "0.2"

--- a/crates/wasi-stub/src/lib.rs
+++ b/crates/wasi-stub/src/lib.rs
@@ -74,15 +74,15 @@ pub fn stub_wasi_functions(
     binary: &[u8],
     should_stub: ShouldStub,
     return_value: u32,
-) -> anyhow::Result<Vec<u8>> {
-    let wat = wasmprinter::print_bytes(binary)?;
+) -> crate::Result<Vec<u8>> {
+    let wat = wasmprinter::print_bytes(binary).map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
     let parse_buffer = wast::parser::ParseBuffer::new(&wat)?;
 
     let mut wat: Wat = wast::parser::parse(&parse_buffer)?;
     let module = match &mut wat {
         Wat::Module(m) => m,
         Wat::Component(_) => {
-            anyhow::bail!("components are not supported")
+            return Err(Error::message("components are not supported"))
         }
     };
     let fields = match &mut module.kind {
@@ -264,3 +264,22 @@ pub fn stub_wasi_functions(
 
     Ok(module.encode()?)
 }
+
+// Error handling
+pub struct Error(Box<dyn std::error::Error + Send + Sync + 'static>);
+impl Error {
+    pub fn message(reason: impl AsRef<str>) -> Self {
+        Self(Box::new(std::io::Error::new(std::io::ErrorKind::Other, reason.as_ref().to_string())))
+    }
+}
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+impl<E> From<E> for Error where E: std::error::Error + Send + Sync + 'static {
+    fn from(err: E) -> Self {
+        Self(Box::new(err))
+    }
+}
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/wasi-stub/src/lib.rs
+++ b/crates/wasi-stub/src/lib.rs
@@ -75,15 +75,14 @@ pub fn stub_wasi_functions(
     should_stub: ShouldStub,
     return_value: u32,
 ) -> crate::Result<Vec<u8>> {
-    let wat = wasmprinter::print_bytes(binary).map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+    let wat = wasmprinter::print_bytes(binary)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
     let parse_buffer = wast::parser::ParseBuffer::new(&wat)?;
 
     let mut wat: Wat = wast::parser::parse(&parse_buffer)?;
     let module = match &mut wat {
         Wat::Module(m) => m,
-        Wat::Component(_) => {
-            return Err(Error::message("components are not supported"))
-        }
+        Wat::Component(_) => return Err(Error::message("components are not supported")),
     };
     let fields = match &mut module.kind {
         ModuleKind::Text(f) => f,
@@ -269,7 +268,10 @@ pub fn stub_wasi_functions(
 pub struct Error(Box<dyn std::error::Error + Send + Sync + 'static>);
 impl Error {
     pub fn message(reason: impl AsRef<str>) -> Self {
-        Self(Box::new(std::io::Error::new(std::io::ErrorKind::Other, reason.as_ref().to_string())))
+        Self(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            reason.as_ref().to_string(),
+        )))
     }
 }
 impl std::fmt::Debug for Error {
@@ -277,7 +279,10 @@ impl std::fmt::Debug for Error {
         std::fmt::Display::fmt(&self.0, f)
     }
 }
-impl<E> From<E> for Error where E: std::error::Error + Send + Sync + 'static {
+impl<E> From<E> for Error
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
     fn from(err: E) -> Self {
         Self(Box::new(err))
     }

--- a/crates/wasi-stub/src/main.rs
+++ b/crates/wasi-stub/src/main.rs
@@ -1,22 +1,9 @@
 mod parse_args;
 
 use std::path::PathBuf;
-use wasi_stub::stub_wasi_functions;
+use wasi_stub::{stub_wasi_functions, Result, Error};
 
-// Error handling
-struct Error(Box<dyn std::fmt::Display>);
-impl std::fmt::Debug for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
-    }
-}
-impl<E: std::fmt::Display + 'static> From<E> for Error {
-    fn from(err: E) -> Self {
-        Self(Box::new(err))
-    }
-}
-
-fn main() -> Result<(), Error> {
+fn main() -> Result<()> {
     let parse_args::Args {
         binary,
         path,
@@ -37,7 +24,7 @@ fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn write_output(path: PathBuf, output_path: Option<PathBuf>, output: Vec<u8>) -> Result<(), Error> {
+fn write_output(path: PathBuf, output_path: Option<PathBuf>, output: Vec<u8>) -> Result<()> {
     let output_path = match output_path {
         Some(p) => p,
         // Try to find an unused output path

--- a/crates/wasi-stub/src/main.rs
+++ b/crates/wasi-stub/src/main.rs
@@ -1,7 +1,7 @@
 mod parse_args;
 
 use std::path::PathBuf;
-use wasi_stub::{stub_wasi_functions, Result, Error};
+use wasi_stub::{stub_wasi_functions, Error, Result};
 
 fn main() -> Result<()> {
     let parse_args::Args {

--- a/crates/wasi-stub/src/parse_args.rs
+++ b/crates/wasi-stub/src/parse_args.rs
@@ -279,7 +279,9 @@ Multiple functions can be given: simply separate them with commas (without white
                 for function in stub_functions.split(',') {
                     let (module, function) = match function.split_once(':') {
                         Some((m, f)) => (m, f),
-                        None => return Err(Error::message(format!("Malformed argument: {function}"))),
+                        None => {
+                            return Err(Error::message(format!("Malformed argument: {function}")))
+                        }
                     };
                     let functions = should_stub
                         .modules

--- a/crates/wasi-stub/src/parse_args.rs
+++ b/crates/wasi-stub/src/parse_args.rs
@@ -254,7 +254,7 @@ Multiple functions can be given: simply separate them with commas (without white
             ],
         );
 
-        arg_parser.parse()?;
+        arg_parser.parse().map_err(Error::message)?;
 
         if arg_parser.requested_help {
             arg_parser.print_help_message();
@@ -279,7 +279,7 @@ Multiple functions can be given: simply separate them with commas (without white
                 for function in stub_functions.split(',') {
                     let (module, function) = match function.split_once(':') {
                         Some((m, f)) => (m, f),
-                        None => return Err(format!("Malformed argument: {function}").into()),
+                        None => return Err(Error::message(format!("Malformed argument: {function}"))),
                     };
                     let functions = should_stub
                         .modules
@@ -310,7 +310,7 @@ Multiple functions can be given: simply separate them with commas (without white
         {
             match value.to_str() {
                 Some(v) => return_value = v.parse()?,
-                None => return Err(format!("Invalid number: {value:?}").into()),
+                None => return Err(Error::message(format!("Invalid number: {value:?}"))),
             }
         }
 


### PR DESCRIPTION
Anyhow is not needed as a dependency for `wasi-stub` and only slows down builds in case version doesn't match with upstream crates.

It can easily be removed by changing:
```rust
struct Error(Box<dyn std::fmt::Display>);
```
into:
```rust
pub struct Error(Box<dyn std::error::Error + Send + Sync + 'static>);
```

Also added `Error::message` fn for convenience.