### PR TITLE
Update reference to crate

### DIFF
--- a/examples/hello_rust/Cargo.toml
+++ b/examples/hello_rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-minimal-protocol = { path = "../../" }
+wasm-minimal-protocol = { path = "../../crates/macro" }
 
 
 [profile.release]


### PR DESCRIPTION
Commit 9561989 changed the root `Cargo.toml` file breaking the `hello_rust` example. This PR fixes the referenced path so that it will compile with the instructions in the readme.